### PR TITLE
adding odds without incorrect math

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ ENV/
 
 # more stuff
 cfbets/static/
+.vscode

--- a/cfbets/bets/forms.py
+++ b/cfbets/bets/forms.py
@@ -25,6 +25,16 @@ class PlaceBetsForm(forms.Form):
             attrs={
                 'autocomplete': 'off'}))
 
+    odds = forms.DecimalField(
+        label='Odds', 
+        initial=1.0, 
+        min_value=0.1, 
+        max_value=10, 
+        help_text="Use decimals e.g. 2.0 for 2:1 or .25 for 1:4.  Ratios from the perspective of the proposer, so 2.0 odds means the proposer stands to win 2 times the bet amount.  0.5 odds means the accepter stands to win 2 times the bet amount.", 
+        widget=forms.TextInput(
+            attrs={
+                'autocomplete':'off'}))
+
     bet_expiration_date = forms.DateTimeField(
         label='Expiration (mm/dd/yyyy 24hr eastern time)',
         help_text='Default is one week from today. Bet will no longer be available for others to accept after this datetime.',

--- a/cfbets/bets/models.py
+++ b/cfbets/bets/models.py
@@ -14,6 +14,8 @@ class ProposedBet (models.Model):
     max_wagers = models.IntegerField()
     remaining_wagers = models.IntegerField()
     end_date = models.DateTimeField()
+    odds = models.DecimalField(default=1.0)
+
 
     # win / loss / tie choices
     WIN = 1
@@ -34,8 +36,8 @@ class ProposedBet (models.Model):
     verbose_name_plural = 'Proposed Bets'
 
     def __unicode__(self):
-        return "{id: %d, user: '%s', prop: '%s', wager: '%d'}" % (
-            self.id, self.user.get_full_name(), self.prop_text, self.prop_wager)
+        return "{id: %d, user: '%s', prop: '%s', wager: '%d', odds: '%f'}" % (
+            self.id, self.user.get_full_name(), self.prop_text, self.prop_wager, self.odds)
 
 # Accepted bet holds all prop bets that are accepted by another user
 class AcceptedBet (models.Model):

--- a/cfbets/bets/templates/bets/base_all_bets.html
+++ b/cfbets/bets/templates/bets/base_all_bets.html
@@ -47,6 +47,7 @@
                         <th>Proposee</th>
                         <th>Prop Bet</th>
                         <th>Wager</th>
+                        <th>Odds</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -56,6 +57,7 @@
                         <td>{{ bet.accepted_user.get_full_name }}</td>
                         <td>{{ bet.accepted_prop.prop_text }}</td>
                         <td>${{ bet.accepted_prop.prop_wager }}</td>
+                        <td>{{ bet.accepted_prop.odds }}</td>
                     </tr>
                     {% endfor %}
                 </tbody>
@@ -75,6 +77,7 @@
                     <th>{% trans "Proposee" %}</th>
                     <th>{% trans "Prop Bet" %}</th>
                     <th>{% trans "Wager" %}</th>
+                    <th>{% trans "Odds" %}</th>
                     <th>{% trans "Winner" %}</th>
                 </tr>
             </thead>

--- a/cfbets/bets/templates/bets/base_my_bets.html
+++ b/cfbets/bets/templates/bets/base_my_bets.html
@@ -44,6 +44,7 @@
                     <tr>
                         <th>Prop Bet</th>
                         <th>Wager</th>
+                        <th>Odds</th>
                         <th>Max Bets</th>
                         <th>Bets Remain</th>
                         <th>End Date</th>
@@ -54,6 +55,7 @@
                     <tr>
                         <td>{{ bet.prop_text }}</td>
                         <td>${{ bet.prop_wager }}</td>
+                        <td>{{ bet.odds }}</td>
                         <td>{{ bet.max_wagers }}</td>
                         <td>{{ bet.remaining_wagers }}</td>
                         <td>{{ bet.end_date|date:"M d Y H:i" }}</td>
@@ -85,6 +87,7 @@
                         <th>Proposee</th>
                         <th>Prop Bet</th>
                         <th>Wager</th>
+                        <th>Odds</th>
                     </tr>
                 </thead>
                 <tfoot>
@@ -102,6 +105,7 @@
                             <td>{{ bet.accepted_user.get_full_name }}</td>
                             <td>{{ bet.accepted_prop.prop_text }}</td>
                             <td>${{ bet.accepted_prop.prop_wager }}</td>
+                            <td>{{ bet.odds }}</td>
                         </tr>
                     {% endfor %}
                 </tbody>
@@ -118,6 +122,7 @@
                 <tr>
                     <th>{% trans "Prop Bet" %}</th>
                     <th>{% trans "Wager" %}</th>
+                    <th>{% trans "Odds" %}</th>
                     <th>{% trans "Against" %}</th>
                     <th>{% trans "Winner" %}</th>
                 </tr>

--- a/cfbets/bets/templates/bets/base_open_bets.html
+++ b/cfbets/bets/templates/bets/base_open_bets.html
@@ -14,6 +14,7 @@
                     <th>Prop Bet</th>
                     <th>User</th>
                     <th>Wager</th>
+                    <th>Odds</th>
                     <th>Bets Remain</th>
                     <th>End Date</th>
                 </tr>
@@ -38,12 +39,14 @@
                                     data-id2="{{ bet.user.get_full_name }}"
                                     data-id3="{{ bet.prop_wager }}"
                                     data-id4="{{ bet.id }}"
+                                    data-id5="{{ bet.odds }}"
                                     title="Accept prop bet"
                                     class="btn btn-success btn-sm open-AcceptBet">Accept</a>
                             </div>
                         </td>
                         <td>{{ bet.user.get_full_name }}</td>
                         <td>${{ bet.prop_wager }}</td>
+                        <td>{{ bet.odds }}</td>
                         <td>{{ bet.remaining_wagers }}</td>
                         <td>{{ bet.end_date|date:"M d Y H:i" }}</td>
                     </tr>
@@ -69,6 +72,7 @@
                 <span id="duplicateBet"></span>
                 <p>Accept <strong>$<span id="betAmount"></span></strong> bet
                     "<strong><span id="betId"></span>"</strong>
+                    with <span id="betOdds"></span> odds
                     proposed by <span id="betUser"></span>?
                 </p>
                 <p><small><i>Note: You are betting <strong>against</strong> this prop bet. This action can't be undone.</i></small></p>
@@ -96,10 +100,13 @@ $('#acceptBet').on('show.bs.modal', function (e) {
     var betText = $(e.relatedTarget).attr('data-id1');
     var betUser = $(e.relatedTarget).attr('data-id2');
     var betAmount = $(e.relatedTarget).attr('data-id3');
+    var betOdds = $(e.relatedTarget).attr('data-id5');
 
     $("#betId").html(betText);
     $("#betUser").html(betUser);
     $("#betAmount").html(betAmount);
+    $("#betOdds").html(betOdds);
+
 
     // get the href link with bet id and place it in the href
     $(this).find('.btn-success').attr('href', $(e.relatedTarget).data('href'));

--- a/cfbets/bets/tests.py
+++ b/cfbets/bets/tests.py
@@ -1,3 +1,4 @@
 from django.test import TestCase
 
 # Create your tests here.
+# LOL


### PR DESCRIPTION
I'm bored, so doing this again.  The user experience could probably use a little work since this is pretty backend-friendly (I'm also very backend-friendly, if you catch my drift)...maybe could build out like a little helper so that they can pick the odds visually and then use that to calculate the decimal value or something.  Or just assume that people using this aren't dumb and know what odds are

### Concerns:
- floating point calculations (e.g. will it think that an odds value is != 1 when it should be one and change the transaction amount).  Probably not, and even if so the change would be negligible since money is only relevant to two decimal places
- John's golf swing and lack of distance
- Trump 